### PR TITLE
Checking if exist $message_to_post

### DIFF
--- a/src/mibew/libs/chat.php
+++ b/src/mibew/libs/chat.php
@@ -707,7 +707,9 @@ function check_for_reassign($thread, $operator)
 			$message_to_post = getstring2_("chat.status.operator.returned", array($operatorName), $thread['locale'], true);
 		}
 
-		post_message($thread['threadid'], $kind_events, $message_to_post);
+		if ($message_to_post)	{
+			post_message($thread['threadid'], $kind_events, $message_to_post);
+		}
 		post_message($thread['threadid'], $kind_avatar, $operator['vcavatar'] ? $operator['vcavatar'] : "");
 	}
 }


### PR DESCRIPTION
I think it's usable, as for me, when I want to disable operator returning message (too many flood, when using mobile device/tablet) in the locales file simply removing the content of variable.

If this checking is not exist, the empty messages with dates will appear in chat.
