### PR TITLE
Enforce password policy

### DIFF
--- a/src/mibew/libs/config.php
+++ b/src/mibew/libs/config.php
@@ -54,4 +54,6 @@ $default_locale = "en"; /* if user does not provide known lang */
  */
 $use_open_basedir_protection = false;
 
+require_once('password-policy.php');
+
 ?>

--- a/src/mibew/libs/password-policy.php
+++ b/src/mibew/libs/password-policy.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * You can set this to a different value.
+ * See http://www.php.net/manual/en/language.types.callable.php
+ */
+$password_policy = 'standard_password_policy';
+
+function standard_password_policy ($pwd) {
+	if (strlen($pwd) < 8) {
+		return false;
+	}
+	if (strlen($pwd) >= 16) {
+		return true;
+	}
+	
+	$character_classes = 0;
+	if (preg_match('/[A-Z]/', $pwd)) $character_classes++;
+	if (preg_match('/[a-z]/', $pwd)) $character_classes++;
+	if (preg_match('/[0-9]/', $pwd)) $character_classes++;
+	if (preg_match('/[^A-Za-z0-9]/', $pwd)) $character_classes++;
+	
+	if ($character_classes >= 3) {
+		return true;
+	}
+	return false;
+}
+
+?>

--- a/src/mibew/locales/en/properties
+++ b/src/mibew/locales/en/properties
@@ -248,6 +248,7 @@ menu.translate=Localize
 menu.updates.content=Check for news and updates.
 menu.updates=Updates
 my_settings.error.password_match=Entered passwords do not match
+my_settings.error.password_policy=Password is too simple
 no_such_operator=No such Operator
 notification.back_to_list=Back to the list
 notification.intro=Contents of sent notification.

--- a/src/mibew/operator/operator.php
+++ b/src/mibew/operator/operator.php
@@ -69,6 +69,11 @@ if (isset($_POST['login']) && isset($_POST['password'])) {
 
 	if ($password != $passwordConfirm)
 		$errors[] = getlocal("my_settings.error.password_match");
+	
+	if ($password_policy) {
+		if (!call_user_func($password_policy, $password))
+			$errors[] = getlocal("my_settings.error.password_policy");
+	}
 
 	$existing_operator = operator_by_login($login);
 	if ((!$opId && $existing_operator) ||


### PR DESCRIPTION
This patch allows you to enforce a password strength policy. It gives you a config variable `$password_policy` which can be set to false (the default) or to [something PHP considers to be callable](http://www.php.net/manual/en/language.types.callable.php) (such as the name of a function, or a class/method pair, or a closure, or whatever). This callable thing should return true if the password is OK, and false otherwise.

A demonstration function is included, which does the following check:
- password is bad if length < 8
- password is ok if length >= 16
- otherwise the password is only ok if it contains at least three of the following:
  - an upper-case character
  - a lower-case character
  - a number
  - a non-alphanumeric character
