### PR TITLE
Prevent use of undefined values on display of chat invitation

### DIFF
--- a/src/mibew/libs/classes/Mibew/Controller/Chat/AbstractController.php
+++ b/src/mibew/libs/classes/Mibew/Controller/Chat/AbstractController.php
@@ -105,9 +105,9 @@ abstract class AbstractController extends BaseAbstractController
                 'mibewBasePath' => $request->getBasePath(),
                 'mibewBaseUrl' => $request->getBaseUrl(),
                 'stylePath' => $request->getBasePath() . '/' . $this->getStyle()->getFilesPath(),
-                'company' => $options['company'],
-                'mibewHost' => $options['mibewHost'],
-                'title' => $options['page.title'],
+                'company' => isset($options['company']) ? $options['company'] : '',
+                'mibewHost' => isset($options['mibewHost']) ? $options['mibewHost'] : '',
+                'title' => isset($options['page.title']) ? $options['page.title'] : '',
             ),
             'startFrom' => $options['startFrom'],
         );


### PR DESCRIPTION
Suppose that in this case there is no need to change `libs/invitation.php` too. One can just make controller class more tolerant to incoming data.