### PR TITLE
Added by the browser cache using .htaccess

### DIFF
--- a/src/mibew/.htaccess
+++ b/src/mibew/.htaccess
@@ -51,3 +51,16 @@ Options +FollowSymLinks
 <FilesMatch "\.(yml|po|ini|handlebars|keep)$">
     Deny from all
 </FilesMatch>
+
+# Turn on Expires
+ExpiresActive On
+ExpiresDefault "access plus 2 days"
+
+# Speed up caching
+FileETag MTime Size
+
+# Set up 2 days caching and specific cache-control for files
+<FilesMatch "\.(.*)\.(js|css|jpg|png|gif|svg)$">
+ ExpiresDefault A172800
+ Header append Cache-Control "proxy-revalidate"
+</FilesMatch>


### PR DESCRIPTION
Added by the browser cache for files (js|css|jpg|png|gif|svg) using .htaccess

Using this type of cache server to the requests will be lower, thus, the application will become faster.

The cache is configured for 2 days.