### PR TITLE
Fix thread ban

### DIFF
--- a/src/mibew/libs/classes/Mibew/Controller/BanController.php
+++ b/src/mibew/libs/classes/Mibew/Controller/BanController.php
@@ -133,7 +133,7 @@ class BanController extends AbstractController
             $page['formcomment'] = $ban->comment;
         } elseif ($request->query->has('thread')) {
             // Prepopulate form using thread data
-            $thread_id = $request->query->has('thread');
+            $thread_id = $request->query->get('thread');
             if (!preg_match("/^\d{1,10}$/", $thread_id)) {
                 throw new BadRequestException('Wrong value of "thread" argument.');
             }


### PR DESCRIPTION
When operator tries to ban some thread by IP address he gets wrong predefined IP in the form for ban, because system always get wrong thread from database (id always equal 1).