### PR TITLE
Fix some typos in variable names and strings

### DIFF
--- a/src/mibew/js/source/chat/app.js
+++ b/src/mibew/js/source/chat/app.js
@@ -51,7 +51,7 @@
                 app.Invitation.start(options.invitationOptions);
                 break;
             default:
-                throw new Error('Dont know how to start!');
+                throw new Error("Don't know how to start!");
                 break;
         }
     });

--- a/src/mibew/js/source/mibewapi.js
+++ b/src/mibew/js/source/mibewapi.js
@@ -185,7 +185,7 @@ MibewAPI.prototype.checkPackage = function (packageObject) {
  *
  * @param {Object[]} functionsList Array of functions. See MibewAPI for
  * function structure details
- * @param {Boolean|null} [existance="null"] (optional) Control existance of
+ * @param {Boolean|null} [existence="null"] (optional) Control existence of
  * the 'result' function in request. Use boolean true if 'result' function
  * must exists in request, boolean false if must not and null if it doesn't
  * matter.
@@ -193,9 +193,9 @@ MibewAPI.prototype.checkPackage = function (packageObject) {
  * null otherwise
  * @throws Error
  */
-MibewAPI.prototype.getResultFunction = function(functionsList, existance){
-    if (typeof existance == "undefined") {
-        existance = null;
+MibewAPI.prototype.getResultFunction = function(functionsList, existence){
+    if (typeof existence == "undefined") {
+        existence = null;
     }
     var resultFunction = null;
     // Try to find result function
@@ -214,11 +214,11 @@ MibewAPI.prototype.getResultFunction = function(functionsList, existance){
             resultFunction = functionsList[i];
         }
     }
-    if (existance === true && resultFunction === null) {
+    if (existence === true && resultFunction === null) {
         // 'result' function must present in request
         throw new Error("There is no 'result' function in functions list");
     }
-    if (existance === false && resultFunction !== null) {
+    if (existence === false && resultFunction !== null) {
         throw new Error("There is 'result' function in functions list");
     }
     return resultFunction;

--- a/src/mibew/libs/classes/Mibew/API/API.php
+++ b/src/mibew/libs/classes/Mibew/API/API.php
@@ -288,7 +288,7 @@ class API
      *
      * @param array $functions_list Array of functions. See Mibew API
      *   specification for function structure details.
-     * @param mixed $existance Control existance of the 'result' function in
+     * @param mixed $existence Control existence of the 'result' function in
      *   request. Use boolean true if 'result' function must exists in request,
      *   boolean false if must not and null if it doesn't matter.
      * @return mixed Function array if 'result' function found and NULL

--- a/src/mibew/libs/classes/Mibew/Cache/CacheFactory.php
+++ b/src/mibew/libs/classes/Mibew/Cache/CacheFactory.php
@@ -152,7 +152,7 @@ class CacheFactory
 
                 // Convert structure from the "memcached_servers" option to the
                 // form used in cache driver.
-                $formated_servers = array_map(function ($server) {
+                $formatted_servers = array_map(function ($server) {
                     return array(
                         $server['host'],
                         intval($server['port']),
@@ -162,7 +162,7 @@ class CacheFactory
 
                 $driver = new MemcacheDriver();
                 $driver->setOptions(array(
-                    'servers' => $formated_servers,
+                    'servers' => $formatted_servers,
                     // Use only PHP's "memcached" extension.
                     'extension' => 'memcached'
                 ));

--- a/src/mibew/libs/classes/Mibew/Plugin/Utils.php
+++ b/src/mibew/libs/classes/Mibew/Plugin/Utils.php
@@ -84,7 +84,7 @@ class Utils
     public static function getPluginClassName($plugin_name)
     {
         if (!self::isValidPluginName($plugin_name)) {
-            throw new \InvalidArgumentException('Wrong formated plugin name');
+            throw new \InvalidArgumentException('Wrong formatted plugin name');
         }
         list($vendor, $short_name) = explode(':', $plugin_name, 2);
 

--- a/src/tests/client_side/qunit/test_cases/mibewapi_tests.js
+++ b/src/tests/client_side/qunit/test_cases/mibewapi_tests.js
@@ -425,7 +425,7 @@ test("getResult", function() {
     }
 
     // Try to get 'result' function from functions list that have no 'result'
-    // function. 'existance' argument set to true
+    // function. 'existence' argument set to true
     try {
         mibewAPI.getResultFunction({}, true);
     } catch (e) {
@@ -437,25 +437,25 @@ test("getResult", function() {
     }
 
     // Try to get 'result' function from functions list that have no 'result'
-    // function. 'existance' argument set to false
+    // function. 'existence' argument set to false
     equal(
         mibewAPI.getResultFunction({}, false),
         null,
-        "Test with no 'result' function in functions list, 'existance' " +
+        "Test with no 'result' function in functions list, 'existence' " +
         "argument equals to false and null as the result functionon returned"
     );
 
     // Try to get 'result' function from functions list that have no 'result'
-    // function. 'existance' argument set to null
+    // function. 'existence' argument set to null
     equal(
         mibewAPI.getResultFunction({}, null),
         null,
-        "Test with no 'result' function in functions list, 'existance' " +
+        "Test with no 'result' function in functions list, 'existence' " +
         "argument equals to null and null as the result functionon returned"
     );
 
     // Try to get 'result' function from functions list that have 'result'
-    // function. 'existance' argument set to false
+    // function. 'existence' argument set to false
     try {
         mibewAPI.getResultFunction([
             {"function" : "result"}


### PR DESCRIPTION
Most of them were found by codespell.

Signed-off-by: Stefan Weil sw@weilnetz.de
