### PR TITLE
Created an Operator Status Controller for External Integration

### DIFF
--- a/src/mibew/configs/routing.yml
+++ b/src/mibew/configs/routing.yml
@@ -90,6 +90,10 @@ button:
     path: /b
     defaults: { _controller: Mibew\Controller\ButtonController::indexAction }
 
+op_status:
+    path: /opstatus
+    defaults: { _controller: Mibew\Controller\OpStatusController::indexAction }
+
 captcha:
     path: /captcha
     defaults: { _controller: Mibew\Controller\CaptchaController::drawAction }

--- a/src/mibew/libs/classes/Mibew/Controller/OpStatusController.php
+++ b/src/mibew/libs/classes/Mibew/Controller/OpStatusController.php
@@ -1,0 +1,58 @@
+<?php
+/*
+ * This file is a part of Mibew Messenger.
+ *
+ * Copyright 2005-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Mibew\Controller;
+
+use Mibew\Settings;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Represents button-related actions
+ */
+class OpStatusController extends AbstractController
+{
+    /**
+     * Returns content of the chat button.
+     *
+     * @param Request $request
+     * @return string Rendered page content
+     */
+    public function indexAction(Request $request)
+    {
+        $group_id = $request->query->get('group', '');
+        if (!preg_match("/^\d{1,8}$/", $group_id)) {
+            $group_id = false;
+        }
+        if ($group_id) {
+            if (Settings::get('enablegroups') == '1') {
+                $group = group_by_id($group_id);
+                if (!$group) {
+                    $group_id = false;
+                }
+            } else {
+                $group_id = false;
+            }
+        }
+
+        // Get image file content
+        $op_status = has_online_operators($group_id) ? true : false;
+        
+        return $op_status;
+    }
+}

--- a/src/mibew/libs/classes/Mibew/Controller/OpStatusController.php
+++ b/src/mibew/libs/classes/Mibew/Controller/OpStatusController.php
@@ -23,12 +23,12 @@ use Mibew\Settings;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
- * Represents button-related actions
+ * Operator Status actions
  */
 class OpStatusController extends AbstractController
 {
     /**
-     * Returns content of the chat button.
+     * Returns true or false of whether an operator is online or not.
      *
      * @param Request $request
      * @return string Rendered page content
@@ -50,7 +50,7 @@ class OpStatusController extends AbstractController
             }
         }
 
-        // Get image file content
+        // Get status of operators in chat. (supports group based status)
         $op_status = has_online_operators($group_id) ? true : false;
         
         return $op_status;


### PR DESCRIPTION
I wanted to have more control for what is displayed based on whether an operator is available or not.

I didn't want to use the default "Leave a Message" system but instead use my own contact form or perhaps something else. Unfortunately, Mibew doesn't offer any ability to do this at the moment. The only options are On/Off with Live Chat/Leave a Message.

This controller creates a new external integration feature that outputs a true or false statement based on the availability of operators.

By using http://example.com/mibew/opstatus you can include as a variable and take actions based on the status value. I think this increases a lot of possibilities for flexibility.

---

I realize this could probably be a plugin instead of submitted as an edit to the core but I couldn't figure out how to create a plugin that modifies the routing.yml file.

If you think this would be better as a plugin, please let me know how to do that and I will convert it to a plugin instead.

---

Oh yea, this Operator Status controller also supports Group ids so the status can be acted upon per group.
