### PR TITLE
Use HTML5 doctype in backend

### DIFF
--- a/src/mibew/styles/pages/default/templates_src/server_side/_layout.handlebars
+++ b/src/mibew/styles/pages/default/templates_src/server_side/_layout.handlebars
@@ -1,8 +1,8 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml"{{#if rtl}} dir="rtl"{{/if}}>
+<!DOCTYPE html>
+<html {{#if rtl}} dir="rtl"{{/if}}>
 
 <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta charset="utf-8">
     <link rel="shortcut icon" href="{{asset "@CurrentStyle/images/favicon.ico"}}" type="image/x-icon"/>
     <title>
         {{title}} - {{l10n "Mibew Messenger"}}


### PR DESCRIPTION
This pull request:
* Switches to the HTML5 doctype (`<!DOCTYPE html>`)
* Removes the xmlns attribute
* Switches to the HTML5 meta tag (`<meta charset="utf-8">`)

Also see: [Use HTML5 doctype in frontend](https://github.com/Mibew/mibew/pull/250).