### PR TITLE
Use HTML5 doctype in frontend

### DIFF
--- a/src/mibew/styles/chats/default/templates_src/server_side/_layout.handlebars
+++ b/src/mibew/styles/chats/default/templates_src/server_side/_layout.handlebars
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xml:lang="en"{{#if rtl}} dir="rtl"{{/if}}>
+<html lang="en"{{#if rtl}} dir="rtl"{{/if}}>
     <head>
         <meta charset="utf-8">
         <title>{{#block "windowTitle"}}{{l10n "Mibew Messenger"}}{{/block}}</title>

--- a/src/mibew/styles/chats/default/templates_src/server_side/_layout.handlebars
+++ b/src/mibew/styles/chats/default/templates_src/server_side/_layout.handlebars
@@ -1,7 +1,7 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"{{#if rtl}} dir="rtl"{{/if}}>
+<!DOCTYPE html>
+<html xml:lang="en"{{#if rtl}} dir="rtl"{{/if}}>
     <head>
-        <meta http-equiv="Content-Type" content="text/html;charset=UTF-8" />
+        <meta charset="utf-8">
         <title>{{#block "windowTitle"}}{{l10n "Mibew Messenger"}}{{/block}}</title>
         <link rel="shortcut icon" href="{{asset "@CurrentStyle/images/favicon.ico"}}" type="image/x-icon" />
         <link rel="stylesheet" type="text/css" href="{{asset "@CurrentStyle/chat.css"}}" media="all" />


### PR DESCRIPTION
This pull request:
* Switches to the HTML5 doctype (<!DOCTYPE html>)
* Removes the xmlns attribute
* Switches to the HTML5 meta tag (<meta charset="utf-8">)

Also see: [Use HTML5 doctype in backend](https://github.com/Mibew/mibew/pull/249).
