### PR TITLE
don't log error thrown in ThreadProcessor.php:349, just abort

### DIFF
--- a/src/mibew/libs/classes/Mibew/RequestProcessor/AbstractProcessor.php
+++ b/src/mibew/libs/classes/Mibew/RequestProcessor/AbstractProcessor.php
@@ -22,6 +22,7 @@ namespace Mibew\RequestProcessor;
 // Import namespaces and classes of the core
 use Mibew\Database;
 use Mibew\EventDispatcher\EventDispatcher;
+use Mibew\Http\Exception\AccessDeniedException;
 use Mibew\RequestProcessor\Exception\AbstractProcessorException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -240,6 +241,9 @@ abstract class AbstractProcessor
                     return $this->buildSyncResponses($this->responses);
                 }
             }
+        } catch (AccessDeniedException $e) {
+            // don't log exception thrown in ThreadProcessor
+            return false;
         } catch (\Exception $e) {
             // Something went wrong. Trigger error event
             $vars = array('exception' => $e);


### PR DESCRIPTION
Fixes #182 .

Logs from this AccessDeniedException (presumably caused by expired user sessions) are not really helpful, occur frequently and distract from more important messages inside error.log. This is my proposal to remove them. It would be great if someone who is more familiar with the code base could comment on the change.

@Mibew/core-developers
