### PR TITLE
fix SSL lock icon link in chat

### DIFF
--- a/src/mibew/js/source/chat/model_views/controls/secure_mode.js
+++ b/src/mibew/js/source/chat/model_views/controls/secure_mode.js
@@ -48,11 +48,15 @@
              * Move to secure chat
              */
             secure: function() {
+                if (window.location.protocol == 'https:') {
+                    return;
+                }
                 var link = this.model.get('link');
                 if (link) {
                     var style = Mibew.Objects.Models.page.get('style');
                     window.location.href = link.replace(/\&amp\;/g, '&')
-                        + (style ? ('&style=' + style) : '');
+                        + (style ? ((link.indexOf('?') > -1 ? '&' : '?')
+                        + 'style=' + style) : '');
                 }
             }
         }


### PR DESCRIPTION
Changes proposed in this pull request:
- Don't do anything if SSL lock icon is clicked in chat window and connection already uses SSL.
- Fix link creation: if link did not already contain parameters starting with `?`, a broken link was generated.

@Mibew/core-developers
