### PR TITLE
add viewport meta tag to control layout on mobile browsers

### DIFF
--- a/src/mibew/styles/chats/dark/templates_src/server_side/_layout.handlebars
+++ b/src/mibew/styles/chats/dark/templates_src/server_side/_layout.handlebars
@@ -2,6 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"{{#if rtl}} dir="rtl"{{/if}}>
     <head>
         <meta http-equiv="Content-Type" content="text/html;charset=UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0" />
         <title>{{#block "windowTitle"}}{{l10n "Mibew Messenger"}}{{/block}}</title>
         <link rel="shortcut icon" href="{{asset "@CurrentStyle/images/favicon.ico"}}" type="image/x-icon" />
         <link rel="stylesheet" type="text/css" href="{{asset "@CurrentStyle/chat.css"}}" media="all" />

--- a/src/mibew/styles/chats/default/templates_src/server_side/_layout.handlebars
+++ b/src/mibew/styles/chats/default/templates_src/server_side/_layout.handlebars
@@ -2,6 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"{{#if rtl}} dir="rtl"{{/if}}>
     <head>
         <meta http-equiv="Content-Type" content="text/html;charset=UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0" />
         <title>{{#block "windowTitle"}}{{l10n "Mibew Messenger"}}{{/block}}</title>
         <link rel="shortcut icon" href="{{asset "@CurrentStyle/images/favicon.ico"}}" type="image/x-icon" />
         <link rel="stylesheet" type="text/css" href="{{asset "@CurrentStyle/chat.css"}}" media="all" />

--- a/src/mibew/styles/pages/dark/templates_src/server_side/_layout.handlebars
+++ b/src/mibew/styles/pages/dark/templates_src/server_side/_layout.handlebars
@@ -3,6 +3,7 @@
 
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0" />
     <link rel="shortcut icon" href="{{asset "@CurrentStyle/images/favicon.ico"}}" type="image/x-icon"/>
     <title>
         {{title}} - {{l10n "Mibew Messenger"}}

--- a/src/mibew/styles/pages/default/templates_src/server_side/_layout.handlebars
+++ b/src/mibew/styles/pages/default/templates_src/server_side/_layout.handlebars
@@ -3,6 +3,7 @@
 
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0" />
     <link rel="shortcut icon" href="{{asset "@CurrentStyle/images/favicon.ico"}}" type="image/x-icon"/>
     <title>
         {{title}} - {{l10n "Mibew Messenger"}}


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- add viewport meta tag to control layout on mobile browsers for dark and default style in front and backend

@Mibew/core-developers
